### PR TITLE
Wildcard generics in Collection and Map arguments

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -150,10 +150,10 @@ public class JSONArray {
      * @param collection
      *            A Collection.
      */
-    public JSONArray(Collection<Object> collection) {
+    public JSONArray(Collection<?> collection) {
         this.myArrayList = new ArrayList<Object>();
         if (collection != null) {
-            Iterator<Object> iter = collection.iterator();
+            Iterator<Object> iter = ((Collection<Object>)collection).iterator();
             while (iter.hasNext()) {
                 this.myArrayList.add(JSONObject.wrap(iter.next()));
             }
@@ -593,7 +593,7 @@ public class JSONArray {
      *            A Collection value.
      * @return this.
      */
-    public JSONArray put(Collection<Object> value) {
+    public JSONArray put(Collection<?> value) {
         this.put(new JSONArray(value));
         return this;
     }
@@ -646,7 +646,7 @@ public class JSONArray {
      *            A Map value.
      * @return this.
      */
-    public JSONArray put(Map<String, Object> value) {
+    public JSONArray put(Map<String, ?> value) {
         this.put(new JSONObject(value));
         return this;
     }
@@ -695,7 +695,7 @@ public class JSONArray {
      * @throws JSONException
      *             If the index is negative or if the value is not finite.
      */
-    public JSONArray put(int index, Collection<Object> value) throws JSONException {
+    public JSONArray put(int index, Collection<?> value) throws JSONException {
         this.put(index, new JSONArray(value));
         return this;
     }
@@ -767,7 +767,7 @@ public class JSONArray {
      *             If the index is negative or if the the value is an invalid
      *             number.
      */
-    public JSONArray put(int index, Map<String, Object> value) throws JSONException {
+    public JSONArray put(int index, Map<String, ?> value) throws JSONException {
         this.put(index, new JSONObject(value));
         return this;
     }

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -242,12 +242,12 @@ public class JSONObject {
      *            the JSONObject.
      * @throws JSONException
      */
-    public JSONObject(Map<String, Object> map) {
+    public JSONObject(Map<String, ?> map) {
         this.map = new HashMap<String, Object>();
         if (map != null) {
-            Iterator<Entry<String, Object>> i = map.entrySet().iterator();
+            Iterator<Entry<String, Object>> i = ((Map<String, Object>)map).entrySet().iterator();
             while (i.hasNext()) {
-                Entry<String, Object> entry = i.next();
+                Entry<String, ?> entry = i.next();
                 Object value = entry.getValue();
                 if (value != null) {
                     this.map.put(entry.getKey(), wrap(value));
@@ -1053,7 +1053,7 @@ public class JSONObject {
      * @return this.
      * @throws JSONException
      */
-    public JSONObject put(String key, Collection<Object> value) throws JSONException {
+    public JSONObject put(String key, Collection<?> value) throws JSONException {
         this.put(key, new JSONArray(value));
         return this;
     }
@@ -1117,7 +1117,7 @@ public class JSONObject {
      * @return this.
      * @throws JSONException
      */
-    public JSONObject put(String key, Map<String, Object> value) throws JSONException {
+    public JSONObject put(String key, Map<String, ?> value) throws JSONException {
         this.put(key, new JSONObject(value));
         return this;
     }


### PR DESCRIPTION
There is a problem with some generics in some function/constructor arguments: for example the constructor
~~~
public JSONArray(Collection<Object> collection)
~~~
won't be catched by:
~~~
List<String> myList = new ArrayList<String>();
JSONArray myJsonArray = new JSONArray(myList);
~~~
but it catches this constructor `public JSONArray(Object array)` and so it throws this exception:
~~~
 org.json.JSONException: JSONArray initial value should be a string or collection or array.
	at org.json.JSONArray.<init>(JSONArray.java:177)
~~~
The reason is that `Collection<Object>` doesn't match all kinds of collections.

The correct way to reference collections of all type of objects would be  `Collection<? extends Object>` or more concisely `Collection<?>`

Hope to see this patch applied because I have a lot of code that gets the above mentioned exception since constructors changed from `public JSONArray(Collection collection)` to `public JSONArray(Collection<Object> collection)`


