### PR TITLE
Unbounded wildcards in Collections and Maps

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -150,10 +150,10 @@ public class JSONArray {
      * @param collection
      *            A Collection.
      */
-    public JSONArray(Collection<Object> collection) {
+    public JSONArray(Collection<?> collection) {
         this.myArrayList = new ArrayList<Object>();
         if (collection != null) {
-            Iterator<Object> iter = collection.iterator();
+            Iterator<?> iter = collection.iterator();
             while (iter.hasNext()) {
                 this.myArrayList.add(JSONObject.wrap(iter.next()));
             }
@@ -593,7 +593,7 @@ public class JSONArray {
      *            A Collection value.
      * @return this.
      */
-    public JSONArray put(Collection<Object> value) {
+    public JSONArray put(Collection<?> value) {
         this.put(new JSONArray(value));
         return this;
     }
@@ -646,7 +646,7 @@ public class JSONArray {
      *            A Map value.
      * @return this.
      */
-    public JSONArray put(Map<String, Object> value) {
+    public JSONArray put(Map<?, ?> value) {
         this.put(new JSONObject(value));
         return this;
     }
@@ -695,7 +695,7 @@ public class JSONArray {
      * @throws JSONException
      *             If the index is negative or if the value is not finite.
      */
-    public JSONArray put(int index, Collection<Object> value) throws JSONException {
+    public JSONArray put(int index, Collection<?> value) throws JSONException {
         this.put(index, new JSONArray(value));
         return this;
     }

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -767,7 +767,7 @@ public class JSONArray {
      *             If the index is negative or if the the value is an invalid
      *             number.
      */
-    public JSONArray put(int index, Map<String, Object> value) throws JSONException {
+    public JSONArray put(int index, Map<?, ?> value) throws JSONException {
         this.put(index, new JSONObject(value));
         return this;
     }

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -643,7 +643,9 @@ public class JSONArray {
      * is produced from a Map.
      *
      * @param value
-     *            A Map value.
+     *           A Map value. The keys of the parameter are usually strings;
+     * 			 if not, then the keys toString() implementation will be
+     *			 used to derive a proper JSON key.
      * @return this.
      */
     public JSONArray put(Map<?, ?> value) {
@@ -761,7 +763,9 @@ public class JSONArray {
      * @param index
      *            The subscript.
      * @param value
-     *            The Map value.
+     *           A Map value. The keys of the parameter are usually strings;
+     * 			 if not, then the keys toString() implementation will be
+     *			 used to derive a proper JSON key.
      * @return this.
      * @throws JSONException
      *             If the index is negative or if the the value is an invalid

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -242,15 +242,13 @@ public class JSONObject {
      *            the JSONObject.
      * @throws JSONException
      */
-    public JSONObject(Map<String, Object> map) {
+    public JSONObject(Map<?,?> map) {
         this.map = new HashMap<String, Object>();
         if (map != null) {
-            Iterator<Entry<String, Object>> i = map.entrySet().iterator();
-            while (i.hasNext()) {
-                Entry<String, Object> entry = i.next();
+			for (Entry<?,?> entry : map.entrySet()) {
                 Object value = entry.getValue();
                 if (value != null) {
-                    this.map.put(entry.getKey(), wrap(value));
+                    this.map.put(entry.getKey().toString(), wrap(value));
                 }
             }
         }
@@ -1053,7 +1051,7 @@ public class JSONObject {
      * @return this.
      * @throws JSONException
      */
-    public JSONObject put(String key, Collection<Object> value) throws JSONException {
+    public JSONObject put(String key, Collection<?> value) throws JSONException {
         this.put(key, new JSONArray(value));
         return this;
     }
@@ -1117,7 +1115,7 @@ public class JSONObject {
      * @return this.
      * @throws JSONException
      */
-    public JSONObject put(String key, Map<String, Object> value) throws JSONException {
+    public JSONObject put(String key, Map<?,?> value) throws JSONException {
         this.put(key, new JSONObject(value));
         return this;
     }
@@ -1512,10 +1510,10 @@ public class JSONObject {
             return value.toString();
         }
         if (value instanceof Map) {
-            return new JSONObject((Map<String, Object>)value).toString();
+            return new JSONObject((Map<?,?>)value).toString();
         }
         if (value instanceof Collection) {
-            return new JSONArray((Collection<Object>) value).toString();
+            return new JSONArray((Collection<?>) value).toString();
         }
         if (value.getClass().isArray()) {
             return new JSONArray(value).toString();
@@ -1557,7 +1555,7 @@ public class JSONObject {
                 return new JSONArray(object);
             }
             if (object instanceof Map) {
-                return new JSONObject((Map<String, Object>) object);
+                return new JSONObject((Map<?,?>) object);
             }
             Package objectPackage = object.getClass().getPackage();
             String objectPackageName = objectPackage != null ? objectPackage
@@ -1595,9 +1593,9 @@ public class JSONObject {
         } else if (value instanceof JSONArray) {
             ((JSONArray) value).write(writer, indentFactor, indent);
         } else if (value instanceof Map) {
-            new JSONObject((Map<String, Object>) value).write(writer, indentFactor, indent);
+            new JSONObject((Map<?,?>) value).write(writer, indentFactor, indent);
         } else if (value instanceof Collection) {
-            new JSONArray((Collection<Object>) value).write(writer, indentFactor,
+            new JSONArray((Collection<?>) value).write(writer, indentFactor,
                     indent);
         } else if (value.getClass().isArray()) {
             new JSONArray(value).write(writer, indentFactor, indent);

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -239,7 +239,9 @@ public class JSONObject {
      *
      * @param map
      *            A map object that can be used to initialize the contents of
-     *            the JSONObject.
+     *            the JSONObject. The keys of the map are usually strings;
+	 *            if not, then the keys toString() implementation will be
+     *            used to derive a proper JSON key.
      * @throws JSONException
      */
     public JSONObject(Map<?,?> map) {
@@ -1111,7 +1113,9 @@ public class JSONObject {
      * @param key
      *            A key string.
      * @param value
-     *            A Map value.
+	 *           A Map value. The keys of the parameter are usually strings;
+	 * 			 if not, then the keys toString() implementation will be
+     *			 used to derive a proper JSON key.
      * @return this.
      * @throws JSONException
      */
@@ -1549,7 +1553,7 @@ public class JSONObject {
             }
 
             if (object instanceof Collection) {
-                return new JSONArray((Collection<Object>) object);
+                return new JSONArray((Collection<?>) object);
             }
             if (object.getClass().isArray()) {
                 return new JSONArray(object);


### PR DESCRIPTION
Generics: use unbounded wildcards instead of Object as generic type.

There is a JSONArray constructor with `(Collection <Object> c)` and another constructor with signature
`(Object o)` . A call with `new JSONArray(new HashSet<Something>())` will not resolve to the 
first constructor, but to the second one. This broke our code when we tried to upgrade from
an older JSON-java version.

There is a similar issue which concerns Maps. Maps with `<?,?>` instead of `<String, Object>` type parameters should be used. So maximum flexibility is gained for the callers.

For details, please refer to example 4.5.1.1. in the java language reference
http://docs.oracle.com/javase/specs/jls/se7/html/jls-4.html#jls-4.5.1

Very much appreciate your efforts. 

P.S.: just saw the very similar pull request (#111 from @domusofsail). 
While i do believe that the changes in my request are a little bit more
complete than the ones incorporated in #111, the remarkable timely coincidence of the two
requests signifies that the principal issue is legitimate.
