### PR TITLE
Faster and simpler JSONArray constructor and trimming of numeric strings.

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -27,7 +27,6 @@ package org.json;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -166,16 +165,10 @@ public class JSONArray {
      * @throws JSONException
      *             If not an array.
      */
-    public JSONArray(Object array) throws JSONException {
+    public JSONArray(Object[] array) throws JSONException {
         this();
-        if (array.getClass().isArray()) {
-            int length = Array.getLength(array);
-            for (int i = 0; i < length; i += 1) {
-                this.put(JSONObject.wrap(Array.get(array, i)));
-            }
-        } else {
-            throw new JSONException(
-                    "JSONArray initial value should be a string or collection or array.");
+        for (int i = 0; i < array.length; i ++) {
+            put(JSONObject.wrap(array[i]));
         }
     }
 
@@ -189,11 +182,10 @@ public class JSONArray {
      *             If there is no value for the index.
      */
     public Object get(int index) throws JSONException {
-        Object object = this.opt(index);
-        if (object == null) {
-            throw new JSONException("JSONArray[" + index + "] not found.");
-        }
-        return object;
+    	if (index < 0 || index >= this.length()) {
+            throw new JSONException("Index out of bounds.");
+    	}
+    	return myArrayList.get(index);
     }
 
     /**

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1518,7 +1518,7 @@ public class JSONObject {
             return new JSONArray((Collection<Object>) value).toString();
         }
         if (value.getClass().isArray()) {
-            return new JSONArray(value).toString();
+            return new JSONArray((Object[]) value).toString();
         }
         return quote(value.toString());
     }
@@ -1554,7 +1554,7 @@ public class JSONObject {
                 return new JSONArray((Collection<Object>) object);
             }
             if (object.getClass().isArray()) {
-                return new JSONArray(object);
+                return new JSONArray((Object[]) object);
             }
             if (object instanceof Map) {
                 return new JSONObject((Map<String, Object>) object);
@@ -1594,14 +1594,19 @@ public class JSONObject {
             ((JSONObject) value).write(writer, indentFactor, indent);
         } else if (value instanceof JSONArray) {
             ((JSONArray) value).write(writer, indentFactor, indent);
-        } else if (value instanceof Map) {
-            new JSONObject((Map<String, Object>) value).write(writer, indentFactor, indent);
-        } else if (value instanceof Collection) {
-            new JSONArray((Collection<Object>) value).write(writer, indentFactor,
-                    indent);
-        } else if (value.getClass().isArray()) {
-            new JSONArray(value).write(writer, indentFactor, indent);
-        } else if (value instanceof Number) {
+        }
+        else if (value instanceof Map) {
+            new JSONObject((Map<String, Object>) value).write(writer,
+            		indentFactor, indent);
+        }
+        else if (value instanceof Collection) {
+            new JSONArray((Collection<Object>) value).write(writer,
+            		indentFactor, indent);
+        }
+        else if (value.getClass().isArray()) {
+            new JSONArray((Object[]) value).write(writer, indentFactor, indent);
+        }
+        else if (value instanceof Number) {
             writer.write(numberToString((Number) value));
         } else if (value instanceof Boolean) {
             writer.write(value.toString());

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -442,20 +442,8 @@ public class JSONObject {
         if (Double.isInfinite(d) || Double.isNaN(d)) {
             return "null";
         }
-
-// Shave off trailing zeros and decimal point, if possible.
-
-        String string = Double.toString(d);
-        if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-                && string.indexOf('E') < 0) {
-            while (string.endsWith("0")) {
-                string = string.substring(0, string.length() - 1);
-            }
-            if (string.endsWith(".")) {
-                string = string.substring(0, string.length() - 1);
-            }
-        }
-        return string;
+        // Shave off trailing zeros and decimal point, if possible.
+        return trimNumericString(Double.toString(d));
     }
 
     /**
@@ -757,6 +745,22 @@ public class JSONObject {
         }
         return ja.length() == 0 ? null : ja;
     }
+    
+    private static String trimNumericString(String num) {
+        final int idx_point = num.indexOf('.');
+        int idx_last = num.length() - 1;
+        if (idx_point > 0 && num.indexOf('e') < 0 &&
+        		num.indexOf('E') < 0) {
+        	while (num.charAt(idx_last) == '0') {
+        		idx_last --;
+        	}
+        	if (idx_last != idx_point) {
+        		idx_last ++;
+        	}
+        	num = num.substring(0, idx_last);
+        }
+    	return num;
+    }
 
     /**
      * Produce a string from a Number.
@@ -769,23 +773,11 @@ public class JSONObject {
      */
     public static String numberToString(Number number) throws JSONException {
         if (number == null) {
-            throw new JSONException("Null pointer");
+            throw new NullPointerException("Number must not be null.");
         }
         testValidity(number);
-
-// Shave off trailing zeros and decimal point, if possible.
-
-        String string = number.toString();
-        if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-                && string.indexOf('E') < 0) {
-            while (string.endsWith("0")) {
-                string = string.substring(0, string.length() - 1);
-            }
-            if (string.endsWith(".")) {
-                string = string.substring(0, string.length() - 1);
-            }
-        }
-        return string;
+        // Shave off trailing zeros and decimal point, if possible.
+        return trimNumericString(number.toString());
     }
 
     /**

--- a/XML.java
+++ b/XML.java
@@ -470,7 +470,7 @@ public class XML {
 
         } else {
             if (object.getClass().isArray()) {
-                object = new JSONArray(object);
+                object = new JSONArray((Object[]) object);
             }
             if (object instanceof JSONArray) {
                 ja = (JSONArray)object;


### PR DESCRIPTION
1. I moved trimming of floating point numeric strings into its own function <code>trimNumericString</code>, as it is used in at least two places in <code>JSONObject</code>. The trimming procedure is simplified and avoids creation of multiple intermediate string objects.

2. The constructor of <code>JSONArray(Object)</code> used to employ reflection for initialization from a Java array. Here, I simply changed the method signature of the constructor to take an argument <code>Object[] array</code> instead of <code>Object array</code>. This then allows us to access and wrap the array elements directly. This does change the org.json library interface because all valid calls to this constructor use an argument that is already an <code>Object[]</code>.
