### PR TITLE
fix toString(JSONArray) to emit object.toString() values

### DIFF
--- a/JSONML.java
+++ b/JSONML.java
@@ -373,6 +373,8 @@ public class JSONML {
                         sb.append(toString((JSONObject)object));
                     } else if (object instanceof JSONArray) {
                         sb.append(toString((JSONArray)object));
+                    } else {
+                        sb.append(object.toString());
                     }
                 }
             } while (i < length);


### PR DESCRIPTION
Please review and post any questions or concerns.
Might have misplaced the branch notes, which are included here:

**What problem does this code solve?**
JSONML converts XML to JSONObject or JSONArray objects. The corresponding toString() methods should generate similar XML.

**Does the change conflict with the JSON spec?**
No

**Any changes to the API?**
No

**Any changes to how the code behaves?**
No changes to exception behavior. JSONML.toString(JSONArray) will now include object.toString(), in addition to string, JSONObject, and JSONArray content output. E.G. boolean output. This will change the output for some XML inputs.

**Does it break the unit tests?**
Yes, but see [https://github.com/stleary/JSON-Java-unit-test/tree/JSONMLTest-for-toString-issue], which will be committed if/when this change is merged.

**Should the documentation be updated?**
No



