### PR TITLE
Implement a method for converting XML read from a Reader object to a JSONObject

### DIFF
--- a/XML.java
+++ b/XML.java
@@ -367,23 +367,14 @@ public class XML {
      */
     public static JSONObject toJSONObject(Reader reader) throws JSONException {
     	
-    	String string = "";
-    	
-    	BufferedReader br = new BufferedReader(reader);
-    	
-    	String line = "";
-    	
-    	try {
-		while( (line = br.readLine()) != null) {
-			string += line;
- 		}
+        JSONObject jo = new JSONObject();
+        XMLTokener x = new XMLTokener(reader);
 
-	} catch (IOException e) {
-		throw new JSONException(e);
-	}
-    	
-    	return toJSONObject(string);
-    	
+        while (x.more() && x.skipPast("<")) {
+            parse(x, jo, null);
+        }
+
+        return jo;
     }
 
     /**

--- a/XML.java
+++ b/XML.java
@@ -357,6 +357,34 @@ public class XML {
         return jo;
     }
 
+    /**
+     * Works like {@link XML#toJSONObject(String)}, but will read the XML 
+     * from a reader object.  
+     * 
+     * @param reader The reader object that the XML will be read from.
+     * @return A JSONObject containing the structured data from the XML read from reader.
+     * @throws JSONException with an IOException as the cause if an I/O error occurs.
+     */
+    public static JSONObject toJSONObject(Reader reader) throws JSONException {
+    	
+    	String string = "";
+    	
+    	BufferedReader br = new BufferedReader(reader);
+    	
+    	String line = "";
+    	
+    	try {
+		while( (line = br.readLine()) != null) {
+			string += line;
+ 		}
+
+	} catch (IOException e) {
+		throw new JSONException(e);
+	}
+    	
+    	return toJSONObject(string);
+    	
+    }
 
     /**
      * Convert a JSONObject into a well-formed, element-normal XML string.

--- a/XML.java
+++ b/XML.java
@@ -358,8 +358,9 @@ public class XML {
     }
 
     /**
-     * Works like {@link XML#toJSONObject(String)}, but will read the XML 
-     * from a reader object.  
+     * Similar to {@link XML#toJSONObject(String)}, but will read the XML 
+     * from a reader object. This method can be used to convert a XML file
+     * to a JSONObject. 
      * 
      * @param reader The reader object that the XML will be read from.
      * @return A JSONObject containing the structured data from the XML read from reader.

--- a/XMLTokener.java
+++ b/XMLTokener.java
@@ -56,6 +56,14 @@ public class XMLTokener extends JSONTokener {
     }
 
     /**
+     * Construct an XMLTokener from a reader
+     * @param reader A reader
+     */
+    public XMLTokenizer(Reader reader) {
+        super(reader);
+    }
+
+    /**
      * Get the text in the CDATA block.
      * @return The string up to the <code>]]&gt;</code>.
      * @throws JSONException If the <code>]]&gt;</code> is not found.


### PR DESCRIPTION
I have implemented a method that overloads XML#toJSONObject(String), but accepts a Reader object as an argument for reading the XML from a character stream.  Most likely, this would be used to convert a XML document to a JSONObject.

The following is example usage of this method to convert an XML file to a JSONObject.

```java
try {
	JSONObject fromXML = XML.toJSONObject(new FileReader(new File("foo.xml")));

	System.out.println(fromXML);

} catch (JSONException e) {
	e.printStackTrace();
} catch (FileNotFoundException e) {
	e.printStackTrace();
}
```