### PR TITLE
Fix JSONArray broken constructor.

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -151,10 +151,10 @@ public class JSONArray implements Iterable<Object> {
      * @param collection
      *            A Collection.
      */
-    public JSONArray(Collection<Object> collection) {
+    public JSONArray(Collection<?> collection) {
         this.myArrayList = new ArrayList<Object>();
         if (collection != null) {
-            Iterator<Object> iter = collection.iterator();
+            Iterator<?> iter = collection.iterator();
             while (iter.hasNext()) {
                 this.myArrayList.add(JSONObject.wrap(iter.next()));
             }

--- a/src/test/java/org/json/JSONArrayTest.java
+++ b/src/test/java/org/json/JSONArrayTest.java
@@ -1,0 +1,18 @@
+package org.json;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Test;
+
+public class JSONArrayTest {
+
+	@Test
+	public void emptyStringCollection() {
+		final Collection<String> strings = new ArrayList<String>();
+		final JSONArray array = new JSONArray(strings);
+		assertEquals("The array is not empty", 0, array.length());
+	}
+}


### PR DESCRIPTION
The JSONArray constructor that takes a Collection only works when a Collection<Object> is given as argument.
It should work for every kind of objects.

A unit test has been added to show this behavoir.