### PR TITLE
Allow JSONArray constructor that takes object collections to take collections of any kind

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -151,10 +151,10 @@ public class JSONArray implements Iterable<Object> {
      * @param collection
      *            A Collection.
      */
-    public JSONArray(Collection<Object> collection) {
+    public JSONArray(Collection<?> collection) {
         this.myArrayList = new ArrayList<Object>();
         if (collection != null) {
-            Iterator<Object> iter = collection.iterator();
+            Iterator<?> iter = collection.iterator();
             while (iter.hasNext()) {
                 this.myArrayList.add(JSONObject.wrap(iter.next()));
             }


### PR DESCRIPTION
Trying to build a new JSONArray from a Collection\<E\> (where E != Object) throws an exception because it uses another constructor that takes an Object as argument which is supposed to be an array.