### PR TITLE
Fixes possible NPE

### DIFF
--- a/XML.java
+++ b/XML.java
@@ -468,10 +468,12 @@ public class XML {
 // XML does not have good support for arrays. If an array appears in a place
 // where XML is lacking, synthesize an <array> element.
 
-        } else {
+        }
+        if(object!=null){
             if (object.getClass().isArray()) {
                 object = new JSONArray(object);
             }
+            
             if (object instanceof JSONArray) {
                 ja = (JSONArray)object;
                 length = ja.length();
@@ -479,12 +481,12 @@ public class XML {
                     sb.append(toString(ja.opt(i), tagName == null ? "array" : tagName));
                 }
                 return sb.toString();
-            } else {
-                string = (object == null) ? "null" : escape(object.toString());
-                return (tagName == null) ? "\"" + string + "\"" :
-                    (string.length() == 0) ? "<" + tagName + "/>" :
-                    "<" + tagName + ">" + string + "</" + tagName + ">";
             }
         }
+        string = (object == null) ? "null" : escape(object.toString());
+        return (tagName == null) ? "\"" + string + "\"" :
+            (string.length() == 0) ? "<" + tagName + "/>" :
+            "<" + tagName + ">" + string + "</" + tagName + ">";
+            
     }
 }

--- a/XML.java
+++ b/XML.java
@@ -1,7 +1,7 @@
 package org.json;
 
 /*
-Copyright (c) 2002 JSON.org
+Copyright (c) 2015 JSON.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,7 @@ import java.util.Iterator;
  * This provides static methods to convert an XML text into a JSONObject,
  * and to covert a JSONObject into an XML text.
  * @author JSON.org
- * @version 2014-05-03
+ * @version 2015-10-14
  */
 public class XML {
 


### PR DESCRIPTION
The comparison for ```(object == null) ? "null" : escape(object.toString())``` was doing nothing, ```escape(object.toString())``` would always be called since ```object``` could never be null at this point. I have added a null check around the possible NPE areas so this check actually does something.

If we want the NPE, then I propose we just change the ```(object == null) ? "null" : escape(object.toString())``` tertiary to ```escape(object.toString())```