### PR TITLE
limited ctor change for 153

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -745,7 +745,7 @@ public class JSONArray implements Iterable<Object> {
      *            A Collection value.
      * @return this.
      */
-    public JSONArray put(Collection<Object> value) {
+    public JSONArray put(Collection<?> value) {
         this.put(new JSONArray(value));
         return this;
     }
@@ -798,7 +798,7 @@ public class JSONArray implements Iterable<Object> {
      *            A Map value.
      * @return this.
      */
-    public JSONArray put(Map<String, Object> value) {
+    public JSONArray put(Map<String, ?> value) {
         this.put(new JSONObject(value));
         return this;
     }
@@ -847,7 +847,7 @@ public class JSONArray implements Iterable<Object> {
      * @throws JSONException
      *             If the index is negative or if the value is not finite.
      */
-    public JSONArray put(int index, Collection<Object> value) throws JSONException {
+    public JSONArray put(int index, Collection<?> value) throws JSONException {
         this.put(index, new JSONArray(value));
         return this;
     }
@@ -919,7 +919,7 @@ public class JSONArray implements Iterable<Object> {
      *             If the index is negative or if the the value is an invalid
      *             number.
      */
-    public JSONArray put(int index, Map<String, Object> value) throws JSONException {
+    public JSONArray put(int index, Map<String, ?> value) throws JSONException {
         this.put(index, new JSONObject(value));
         return this;
     }

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -151,12 +151,11 @@ public class JSONArray implements Iterable<Object> {
      * @param collection
      *            A Collection.
      */
-    public JSONArray(Collection<Object> collection) {
+    public JSONArray(Collection<?> collection) {
         this.myArrayList = new ArrayList<Object>();
         if (collection != null) {
-            Iterator<Object> iter = collection.iterator();
-            while (iter.hasNext()) {
-                this.myArrayList.add(JSONObject.wrap(iter.next()));
+            for (Object o: collection){
+                this.myArrayList.add(JSONObject.wrap(o));
             }
         }
     }

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -243,15 +243,13 @@ public class JSONObject {
      *            the JSONObject.
      * @throws JSONException
      */
-    public JSONObject(Map<String, Object> map) {
+    public JSONObject(Map<String, ?> map) {
         this.map = new HashMap<String, Object>();
         if (map != null) {
-            Iterator<Entry<String, Object>> i = map.entrySet().iterator();
-            while (i.hasNext()) {
-                Entry<String, Object> entry = i.next();
-                Object value = entry.getValue();
+            for (final Entry<String, ?> e : map.entrySet()) {
+                final Object value = e.getValue();
                 if (value != null) {
-                    this.map.put(entry.getKey(), wrap(value));
+                    this.map.put(String.valueOf(e.getKey()), wrap(value));
                 }
             }
         }

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1202,7 +1202,7 @@ public class JSONObject {
      * @return this.
      * @throws JSONException
      */
-    public JSONObject put(String key, Collection<Object> value) throws JSONException {
+    public JSONObject put(String key, Collection<?> value) throws JSONException {
         this.put(key, new JSONArray(value));
         return this;
     }
@@ -1266,7 +1266,7 @@ public class JSONObject {
      * @return this.
      * @throws JSONException
      */
-    public JSONObject put(String key, Map<String, Object> value) throws JSONException {
+    public JSONObject put(String key, Map<String, ?> value) throws JSONException {
         this.put(key, new JSONObject(value));
         return this;
     }


### PR DESCRIPTION
Not proposing this for the https://github.com/douglascrockford/JSON-java/pull/153  bug fix at this time. Just wanted to open it for comments and be able to reference it from other branches. This branch changes the ctors and some put() methods to support JSONObject(Map&lt;String, ?>) and JSONArray(Collection&lt;?>) in the style of https://github.com/douglascrockford/JSON-java/pull/153, but makes no other changes. In order complete the unit tests, JSONObjectTest instances of Map&lt;?,?> have to be changed to Map&lt;String, ?>