### PR TITLE
Include latest Maven release information

### DIFF
--- a/README
+++ b/README
@@ -62,3 +62,10 @@ JSONML.java: JSONML provides support for converting between JSONML and XML.
 XMLTokener.java: XMLTokener extends JSONTokener for parsing XML text.
 
 Unit tests are maintained in a separate project. Contributing developers can test JSON-java pull requests with the code in this project: https://github.com/stleary/JSON-Java-unit-test
+
+Release history:
+
+20150729    Checkpoint for Maven central repository release. Contains the latest code as of 29 July, 2015. 
+
+JSON-java releases can be found by searching the Maven repository for groupId "org.json" and artifactId "json". For example: 
+https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.json%22%20AND%20a%3A%22json%22


### PR DESCRIPTION
Compare to https://github.com/douglascrockford/JSON-java/pull/152. This changes only the text, does not convert the README to a form that supports markup.