### PR TITLE
Empty arrays fix

### DIFF
--- a/XML.java
+++ b/XML.java
@@ -430,6 +430,9 @@ public class XML {
                 } else if (value instanceof JSONArray) {
                     ja = (JSONArray)value;
                     length = ja.length();
+					if(length == 0) {
+                        sb.append(toString("", key));
+                    }
                     for (i = 0; i < length; i += 1) {
                         value = ja.get(i);
                         if (value instanceof JSONArray) {

--- a/XML.java
+++ b/XML.java
@@ -430,7 +430,7 @@ public class XML {
                 } else if (value instanceof JSONArray) {
                     ja = (JSONArray)value;
                     length = ja.length();
-					if(length == 0) {
+                    if(length == 0) {
                         sb.append(toString("", key));
                     }
                     for (i = 0; i < length; i += 1) {


### PR DESCRIPTION
If array field is empty in source json then it will be completely omitted during json-> xml transformation. Here is small fix for this problem.
 