### PR TITLE
Handle arrays consistently

### DIFF
--- a/XML.java
+++ b/XML.java
@@ -27,49 +27,54 @@ SOFTWARE.
 import java.util.Iterator;
 
 /**
- * This provides static methods to convert an XML text into a JSONObject,
- * and to covert a JSONObject into an XML text.
+ * This provides static methods to convert an XML text into a JSONObject, and to
+ * covert a JSONObject into an XML text.
+ * 
  * @author JSON.org
  * @version 2015-10-18
  */
+@SuppressWarnings("boxing")
 public class XML {
 
     /** The Character '&amp;'. */
-    public static final Character AMP   = '&';
+    public static final Character AMP = '&';
 
     /** The Character '''. */
-    public static final Character APOS  = '\'';
+    public static final Character APOS = '\'';
 
     /** The Character '!'. */
-    public static final Character BANG  = '!';
+    public static final Character BANG = '!';
 
     /** The Character '='. */
-    public static final Character EQ    = '=';
+    public static final Character EQ = '=';
 
     /** The Character '>'. */
-    public static final Character GT    = '>';
+    public static final Character GT = '>';
 
     /** The Character '&lt;'. */
-    public static final Character LT    = '<';
+    public static final Character LT = '<';
 
     /** The Character '?'. */
     public static final Character QUEST = '?';
 
     /** The Character '"'. */
-    public static final Character QUOT  = '"';
+    public static final Character QUOT = '"';
 
     /** The Character '/'. */
     public static final Character SLASH = '/';
 
     /**
      * Replace special characters with XML escapes:
+     * 
      * <pre>
      * &amp; <small>(ampersand)</small> is replaced by &amp;amp;
      * &lt; <small>(less than)</small> is replaced by &amp;lt;
      * &gt; <small>(greater than)</small> is replaced by &amp;gt;
      * &quot; <small>(double quote)</small> is replaced by &amp;quot;
      * </pre>
-     * @param string The string to be escaped.
+     * 
+     * @param string
+     *            The string to be escaped.
      * @return The escaped string.
      */
     public static String escape(String string) {
@@ -100,9 +105,11 @@ public class XML {
     }
 
     /**
-     * Throw an exception if the string contains whitespace.
-     * Whitespace is not allowed in tagNames and attributes.
-     * @param string A string.
+     * Throw an exception if the string contains whitespace. Whitespace is not
+     * allowed in tagNames and attributes.
+     * 
+     * @param string
+     *            A string.
      * @throws JSONException
      */
     public static void noSpace(String string) throws JSONException {
@@ -112,42 +119,46 @@ public class XML {
         }
         for (i = 0; i < length; i += 1) {
             if (Character.isWhitespace(string.charAt(i))) {
-                throw new JSONException("'" + string +
-                        "' contains a space character.");
+                throw new JSONException("'" + string
+                        + "' contains a space character.");
             }
         }
     }
 
     /**
      * Scan the content following the named tag, attaching it to the context.
-     * @param x       The XMLTokener containing the source string.
-     * @param context The JSONObject that will include the new material.
-     * @param name    The tag name.
+     * 
+     * @param x
+     *            The XMLTokener containing the source string.
+     * @param context
+     *            The JSONObject that will include the new material.
+     * @param name
+     *            The tag name.
      * @return true if the close tag is processed.
      * @throws JSONException
      */
-    private static boolean parse(XMLTokener x, JSONObject context,
-                                 String name) throws JSONException {
-        char       c;
-        int        i;
+    private static boolean parse(XMLTokener x, JSONObject context, String name)
+            throws JSONException {
+        char c;
+        int i;
         JSONObject jsonobject = null;
-        String     string;
-        String     tagName;
-        Object     token;
+        String string;
+        String tagName;
+        Object token;
 
-// Test for and skip past these forms:
-//      <!-- ... -->
-//      <!   ...   >
-//      <![  ... ]]>
-//      <?   ...  ?>
-// Report errors for these forms:
-//      <>
-//      <=
-//      <<
+        // Test for and skip past these forms:
+        // <!-- ... -->
+        // <! ... >
+        // <![ ... ]]>
+        // <? ... ?>
+        // Report errors for these forms:
+        // <>
+        // <=
+        // <<
 
         token = x.nextToken();
 
-// <!
+        // <!
 
         if (token == BANG) {
             c = x.next();
@@ -184,13 +195,12 @@ public class XML {
             return false;
         } else if (token == QUEST) {
 
-// <?
-
+            // <?
             x.skipPast("?>");
             return false;
         } else if (token == SLASH) {
 
-// Close tag </
+            // Close tag </
 
             token = x.nextToken();
             if (name == null) {
@@ -207,10 +217,10 @@ public class XML {
         } else if (token instanceof Character) {
             throw x.syntaxError("Misshaped tag");
 
-// Open tag <
+            // Open tag <
 
         } else {
-            tagName = (String)token;
+            tagName = (String) token;
             token = null;
             jsonobject = new JSONObject();
             for (;;) {
@@ -218,10 +228,9 @@ public class XML {
                     token = x.nextToken();
                 }
 
-// attribute = value
-
+                // attribute = value
                 if (token instanceof String) {
-                    string = (String)token;
+                    string = (String) token;
                     token = x.nextToken();
                     if (token == EQ) {
                         token = x.nextToken();
@@ -229,15 +238,15 @@ public class XML {
                             throw x.syntaxError("Missing value");
                         }
                         jsonobject.accumulate(string,
-                                XML.stringToValue((String)token));
+                                XML.stringToValue((String) token));
                         token = null;
                     } else {
                         jsonobject.accumulate(string, "");
                     }
 
-// Empty tag <.../>
 
                 } else if (token == SLASH) {
+                    // Empty tag <.../>
                     if (x.nextToken() != GT) {
                         throw x.syntaxError("Misshaped tag");
                     }
@@ -248,9 +257,8 @@ public class XML {
                     }
                     return false;
 
-// Content, between <...> and </...>
-
                 } else if (token == GT) {
+                    // Content, between <...> and </...>
                     for (;;) {
                         token = x.nextContent();
                         if (token == null) {
@@ -259,20 +267,19 @@ public class XML {
                             }
                             return false;
                         } else if (token instanceof String) {
-                            string = (String)token;
+                            string = (String) token;
                             if (string.length() > 0) {
                                 jsonobject.accumulate("content",
                                         XML.stringToValue(string));
                             }
 
-// Nested element
-
                         } else if (token == LT) {
+                            // Nested element
                             if (parse(x, jsonobject, tagName)) {
                                 if (jsonobject.length() == 0) {
                                     context.accumulate(tagName, "");
-                                } else if (jsonobject.length() == 1 &&
-                                       jsonobject.opt("content") != null) {
+                                } else if (jsonobject.length() == 1
+                                        && jsonobject.opt("content") != null) {
                                     context.accumulate(tagName,
                                             jsonobject.opt("content"));
                                 } else {
@@ -289,14 +296,15 @@ public class XML {
         }
     }
 
-
     /**
      * Try to convert a string into a number, boolean, or null. If the string
      * can't be converted, return the string. This is much less ambitious than
      * JSONObject.stringToValue, especially because it does not attempt to
      * convert plus forms, octal forms, hex forms, or E forms lacking decimal
      * points.
-     * @param string A String.
+     * 
+     * @param string
+     *            A String.
      * @return A simple JSON value.
      */
     public static Object stringToValue(String string) {
@@ -310,9 +318,8 @@ public class XML {
             return JSONObject.NULL;
         }
 
-// If it might be a number, try converting it, first as a Long, and then as a
-// Double. If that doesn't work, return the string.
-
+        // If it might be a number, try converting it, first as a Long, and then
+        // as a Double. If that doesn't work, return the string.
         try {
             char initial = string.charAt(0);
             if (initial == '-' || (initial >= '0' && initial <= '9')) {
@@ -321,30 +328,31 @@ public class XML {
                     return value;
                 }
             }
-        }  catch (Exception ignore) {
+        } catch (Exception ignore) {
             try {
                 Double value = new Double(string);
                 if (value.toString().equals(string)) {
                     return value;
                 }
-            }  catch (Exception ignoreAlso) {
+            } catch (Exception ignoreAlso) {
             }
         }
         return string;
     }
 
-
     /**
      * Convert a well-formed (but not necessarily valid) XML string into a
-     * JSONObject. Some information may be lost in this transformation
-     * because JSON is a data format and XML is a document format. XML uses
-     * elements, attributes, and content text, while JSON uses unordered
-     * collections of name/value pairs and arrays of values. JSON does not
-     * does not like to distinguish between elements and attributes.
-     * Sequences of similar elements are represented as JSONArrays. Content
-     * text may be placed in a "content" member. Comments, prologs, DTDs, and
-     * <code>&lt;[ [ ]]></code> are ignored.
-     * @param string The source string.
+     * JSONObject. Some information may be lost in this transformation because
+     * JSON is a data format and XML is a document format. XML uses elements,
+     * attributes, and content text, while JSON uses unordered collections of
+     * name/value pairs and arrays of values. JSON does not does not like to
+     * distinguish between elements and attributes. Sequences of similar
+     * elements are represented as JSONArrays. Content text may be placed in a
+     * "content" member. Comments, prologs, DTDs, and <code>&lt;[ [ ]]></code>
+     * are ignored.
+     * 
+     * @param string
+     *            The source string.
      * @return A JSONObject containing the structured data from the XML string.
      * @throws JSONException
      */
@@ -357,65 +365,64 @@ public class XML {
         return jo;
     }
 
-
     /**
      * Convert a JSONObject into a well-formed, element-normal XML string.
-     * @param object A JSONObject.
-     * @return  A string.
-     * @throws  JSONException
+     * 
+     * @param object
+     *            A JSONObject.
+     * @return A string.
+     * @throws JSONException
      */
     public static String toString(Object object) throws JSONException {
         return toString(object, null);
     }
 
-
     /**
      * Convert a JSONObject into a well-formed, element-normal XML string.
-     * @param object A JSONObject.
-     * @param tagName The optional name of the enclosing tag.
+     * 
+     * @param object
+     *            A JSONObject.
+     * @param tagName
+     *            The optional name of the enclosing tag.
      * @return A string.
      * @throws JSONException
      */
     public static String toString(Object object, String tagName)
             throws JSONException {
-        StringBuilder       sb = new StringBuilder();
-        JSONArray           ja;
-        JSONObject          jo;
-        String              key;
-        Iterator<String>    keys;
-        String              string;
-        Object              value;
-        
+        StringBuilder sb = new StringBuilder();
+        JSONArray ja;
+        JSONObject jo;
+        String key;
+        Iterator<String> keys;
+        String string;
+        Object value;
+
         if (object instanceof JSONObject) {
 
-// Emit <tagName>
-
+            // Emit <tagName>
             if (tagName != null) {
                 sb.append('<');
                 sb.append(tagName);
                 sb.append('>');
             }
 
-// Loop thru the keys.
-
-            jo = (JSONObject)object;
+            // Loop thru the keys.
+            jo = (JSONObject) object;
             keys = jo.keys();
             while (keys.hasNext()) {
                 key = keys.next();
                 value = jo.opt(key);
                 if (value == null) {
                     value = "";
-                }else if(value.getClass().isArray()){
+                } else if (value.getClass().isArray()) {
                     value = new JSONArray(value);
                 }
-                string = value instanceof String ? (String)value : null;
-                
+                string = value instanceof String ? (String) value : null;
 
-// Emit content in body
-
+                // Emit content in body
                 if ("content".equals(key)) {
                     if (value instanceof JSONArray) {
-                        ja = (JSONArray)value;
+                        ja = (JSONArray) value;
                         int i = 0;
                         for (Object val : ja) {
                             if (i > 0) {
@@ -428,10 +435,10 @@ public class XML {
                         sb.append(escape(value.toString()));
                     }
 
-// Emit an array of similar keys
+                    // Emit an array of similar keys
 
                 } else if (value instanceof JSONArray) {
-                    ja = (JSONArray)value;
+                    ja = (JSONArray) value;
                     for (Object val : ja) {
                         if (val instanceof JSONArray) {
                             sb.append('<');
@@ -450,7 +457,7 @@ public class XML {
                     sb.append(key);
                     sb.append("/>");
 
-// Emit a new tag <k>
+                    // Emit a new tag <k>
 
                 } else {
                     sb.append(toString(value, key));
@@ -458,35 +465,36 @@ public class XML {
             }
             if (tagName != null) {
 
-// Emit the </tagname> close tag
-
+                // Emit the </tagname> close tag
                 sb.append("</");
                 sb.append(tagName);
                 sb.append('>');
             }
             return sb.toString();
 
-// XML does not have good support for arrays. If an array appears in a place
-// where XML is lacking, synthesize an <array> element.
-
         }
-        if(object!=null){
+
+        if (object != null) {
             if (object.getClass().isArray()) {
                 object = new JSONArray(object);
             }
-            
+
             if (object instanceof JSONArray) {
-                ja = (JSONArray)object;
+                ja = (JSONArray) object;
                 for (Object val : ja) {
+                    // XML does not have good support for arrays. If an array
+                    // appears in a place where XML is lacking, synthesize an
+                    // <array> element.
                     sb.append(toString(val, tagName == null ? "array" : tagName));
                 }
                 return sb.toString();
             }
         }
+
         string = (object == null) ? "null" : escape(object.toString());
-        return (tagName == null) ? "\"" + string + "\"" :
-            (string.length() == 0) ? "<" + tagName + "/>" :
-            "<" + tagName + ">" + string + "</" + tagName + ">";
-            
+        return (tagName == null) ? "\"" + string + "\""
+                : (string.length() == 0) ? "<" + tagName + "/>" : "<" + tagName
+                        + ">" + string + "</" + tagName + ">";
+
     }
 }

--- a/XML.java
+++ b/XML.java
@@ -406,8 +406,11 @@ public class XML {
                 value = jo.opt(key);
                 if (value == null) {
                     value = "";
+                }else if(value.getClass().isArray()){
+                    value = new JSONArray(value);
                 }
                 string = value instanceof String ? (String)value : null;
+                
 
 // Emit content in body
 

--- a/XML.java
+++ b/XML.java
@@ -379,14 +379,13 @@ public class XML {
     public static String toString(Object object, String tagName)
             throws JSONException {
         StringBuilder       sb = new StringBuilder();
-        int                 i;
         JSONArray           ja;
         JSONObject          jo;
         String              key;
         Iterator<String>    keys;
-        int                 length;
         String              string;
         Object              value;
+        
         if (object instanceof JSONObject) {
 
 // Emit <tagName>
@@ -417,12 +416,13 @@ public class XML {
                 if ("content".equals(key)) {
                     if (value instanceof JSONArray) {
                         ja = (JSONArray)value;
-                        length = ja.length();
-                        for (i = 0; i < length; i += 1) {
+                        int i = 0;
+                        for (Object val : ja) {
                             if (i > 0) {
                                 sb.append('\n');
                             }
-                            sb.append(escape(ja.get(i).toString()));
+                            sb.append(escape(val.toString()));
+                            i++;
                         }
                     } else {
                         sb.append(escape(value.toString()));
@@ -432,19 +432,17 @@ public class XML {
 
                 } else if (value instanceof JSONArray) {
                     ja = (JSONArray)value;
-                    length = ja.length();
-                    for (i = 0; i < length; i += 1) {
-                        value = ja.get(i);
-                        if (value instanceof JSONArray) {
+                    for (Object val : ja) {
+                        if (val instanceof JSONArray) {
                             sb.append('<');
                             sb.append(key);
                             sb.append('>');
-                            sb.append(toString(value));
+                            sb.append(toString(val));
                             sb.append("</");
                             sb.append(key);
                             sb.append('>');
                         } else {
-                            sb.append(toString(value, key));
+                            sb.append(toString(val, key));
                         }
                     }
                 } else if ("".equals(value)) {
@@ -479,9 +477,8 @@ public class XML {
             
             if (object instanceof JSONArray) {
                 ja = (JSONArray)object;
-                length = ja.length();
-                for (i = 0; i < length; i += 1) {
-                    sb.append(toString(ja.opt(i), tagName == null ? "array" : tagName));
+                for (Object val : ja) {
+                    sb.append(toString(val, tagName == null ? "array" : tagName));
                 }
                 return sb.toString();
             }


### PR DESCRIPTION
There is some code in the XML converter that tries to wrap arrays into a JSONArray, but does so inconsistently. This causes some disconnect between the handling of a native Java Array and the JSONArray object when conversion to XML occurs.

This PR also updates the loops over the JSONArrays to use the new iterable for loops introduced in Java5 as well as updates some comment formatting to be more consistent with other files in the project.