### PR TITLE
Update readme for 20151123 release

### DIFF
--- a/README
+++ b/README
@@ -65,6 +65,9 @@ Unit tests are maintained in a separate project. Contributing developers can tes
 
 Release history:
 
+20151123    JSONObject and JSONArray initialization with generics. Contains the
+latest code as of 23 Nov, 2015.
+
 20150729    Checkpoint for Maven central repository release. Contains the latest code as of 29 July, 2015. 
 
 JSON-java releases can be found by searching the Maven repository for groupId "org.json" and artifactId "json". For example: 


### PR DESCRIPTION
Proposing a new release on 23 Nov 2015. No input has been received on generics support after 3 weeks, so proceeding with GitHub and Maven releases. Please comment if you see anything that was missed or have any new concerns about the release. For more information on how releases are made on this project, see https://github.com/douglascrockford/JSON-java/wiki/How-to-make-a-new-JSON-java-release

**Label:** 20151123
**Title:** JSONObject and JSONArray initialization with generics
**Text:** Provide support for generic maps and lists. A use case was identified where the JSONObject and JSONArray constructors could not be used to initialize Map&lt;String, String> 
and Collection&lt;String> objects. In this release, Map&lt;?,?> and Collection&lt;?> initialization is
supported.

**Includes the following commits:**

| Pull request | Description |
|----|----|
https://github.com/douglascrockford/JSON-java/pull/168| Update Readme for Maven release 
https://github.com/douglascrockford/JSON-java/pull/160| Fixe possible NullPointerException
https://github.com/douglascrockford/JSON-java/pull/159| Properly override Exception class
https://github.com/douglascrockford/JSON-java/pull/153| JSONObject and JSONArray initialization
