### PR TITLE
Update JavaDoc for JSONObject Constructors

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -165,10 +165,6 @@ public class JSONObject {
      *            A JSONObject.
      * @param names
      *            An array of strings.
-     * @throws JSONException
-     * @exception JSONException
-     *                If a value is a non-finite number or if a name is
-     *                duplicated.
      */
     public JSONObject(JSONObject jo, String[] names) {
         this();
@@ -241,7 +237,6 @@ public class JSONObject {
      * @param map
      *            A map object that can be used to initialize the contents of
      *            the JSONObject.
-     * @throws JSONException
      */
     public JSONObject(Map<?, ?> map) {
         this.map = new HashMap<String, Object>();


### PR DESCRIPTION
Two JSONObject constructors incorrectly specify a @throws JSONException
tag in the JavaDoc for those constructors. Remove the relevant JavaDoc.