### PR TITLE
multi-catch fixed for source release compatibility 1.6

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -593,7 +593,9 @@ public class JSONArray implements Iterable<Object> {
                 return myE;
             }
             return Enum.valueOf(clazz, val.toString());
-        } catch (IllegalArgumentException | NullPointerException e) {
+        } catch (IllegalArgumentException iae) {
+            return defaultValue;
+        } catch (NullPointerException npe) {
             return defaultValue;
         }
     }

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -900,7 +900,9 @@ public class JSONObject {
                 return myE;
             }
             return Enum.valueOf(clazz, val.toString());
-        } catch (IllegalArgumentException | NullPointerException e) {
+        } catch (IllegalArgumentException iae) {
+            return defaultValue;
+        } catch (NullPointerException npe) {
             return defaultValue;
         }
     }


### PR DESCRIPTION
Two lines in each file fixed for source code compatible `1.6`.
I believe these changes don't affect any functionalities and API changes.
Note that sticking source release `1.6` doesn't mean target class version should be `1.6`.

```
$ javac -source 1.6 -target 1.6 -d target *.java
warning: [options] bootstrap class path not set in conjunction with -source 1.6
1 warning
$ javac -source 1.6 -target 1.7 -d target *.java
warning: [options] bootstrap class path not set in conjunction with -source 1.6
1 warning
$ javac -source 1.6 -target 1.8 -d target *.java
warning: [options] bootstrap class path not set in conjunction with -source 1.6
1 warning
$
```
Note, also, that even [Java 9 might support `1.6`](http://openjdk.java.net/jeps/182).