### PR TITLE
change to public: write(writer, indentfactor, indent)

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -1083,6 +1083,8 @@ public class JSONArray implements Iterable<Object> {
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
+     * @param writer
+     *            Writes the serialized JSON
      * @param indentFactor
      *            The number of spaces to add to each level of indentation.
      * @param indent
@@ -1090,7 +1092,7 @@ public class JSONArray implements Iterable<Object> {
      * @return The writer.
      * @throws JSONException
      */
-    Writer write(Writer writer, int indentFactor, int indent)
+    public Writer write(Writer writer, int indentFactor, int indent)
             throws JSONException {
         try {
             boolean commanate = false;

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1781,10 +1781,16 @@ public class JSONObject {
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
+     * @param writer
+     *            Writes the serialized JSON
+     * @param indentFactor
+     *            The number of spaces to add to each level of indentation.
+     * @param indent
+     *            The indention of the top level.
      * @return The writer.
      * @throws JSONException
      */
-    Writer write(Writer writer, int indentFactor, int indent)
+    public Writer write(Writer writer, int indentFactor, int indent)
             throws JSONException {
         try {
             boolean commanate = false;


### PR DESCRIPTION
**What problem does this code solve?**
Some users prefer more fine tuned control over JSONObject.write() and JSONArray.write()

**Changes to the API?**
*JSONObject.write(Writer writer, int indentFactor, int indent)* and *JSONArray.write(Writer writer, int indentFactor, int indent)* are both made public

**Changes to how the code behaves?**
No.

**Does it break the unit tests?**
No. No unit tests were added since the coverage of these two methods is already acceptable.

**Will this require a new release?**
No, this change will be rolled into the next release.

**Should the documentation be updated?**
No.